### PR TITLE
Support 'Symbol.for(nodejs.util.promisify.custom)'

### DIFF
--- a/node/fs.js
+++ b/node/fs.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { ReadStream, WriteStream } = require('./fs/stream')
-const { isBufferLike } = require('../util')
+const { isBufferLike, isFunction } = require('../util')
 const { Dir, Dirent } = require('./fs/dir')
 const { FileHandle } = require('./fs/handle')
 const { Stats } = require('./fs/stats')
@@ -476,4 +476,11 @@ module.exports = {
   write,
   writeFile,
   writev
+}
+
+for (const key in module.exports) {
+  const value = module.exports[key]
+  if (key in promises && isFunction(value) && isFunction(promises[key])) {
+    value[Symbol.for('nodejs.util.promisify.custom')] = promises[key]
+  }
 }

--- a/test/node/fs.js
+++ b/test/node/fs.js
@@ -1,8 +1,9 @@
 'use strict'
 
+const { promisify } = require('util')
 const mock = require('./mock')
 
-const fs = require('../../node/fs/promises')
+const fs = require('../../node/fs')
 const { test } = require('tape')
 
 test('FileHandle', async t => {
@@ -11,6 +12,17 @@ test('FileHandle', async t => {
     {}
   )
 
-  const handle = await fs.open('./foo.txt')
+  const handle = await fs.promises.open('./foo.txt')
   t.ok(handle.id.toString().length, 'handle provides an id')
+})
+
+test('nodejs.util.promisify.custom', (t) => {
+  for (const key in fs) {
+    const value = fs[key]
+    if (typeof fs.promises[key] === 'function') {
+      t.equal(promisify(value), fs.promises[key], `promisify(fs.${key})`)
+    }
+  }
+
+  t.end()
 })

--- a/util.js
+++ b/util.js
@@ -12,6 +12,10 @@ function isBufferLike (object) {
   return isTypedArray(object) || Buffer.isBuffer(object)
 }
 
+function isFunction (value) {
+  return typeof value === 'function' && !/class/.test(value.toString())
+}
+
 function toBuffer (object) {
   if (Buffer.isBuffer(object)) {
     return object
@@ -35,6 +39,7 @@ function rand64 () {
 
 module.exports = {
   isBufferLike,
+  isFunction,
   isTypedArray,
   rand64,
   toBuffer,


### PR DESCRIPTION
This will allow callers of `util.promisify` from node stdlib to call it on our `fs.*` callback based functions and safely get the promise based implementation. This is for completeness as userspace should just require `@socketsupply/io/node/fs/promises` 

```js
const util = require('util')
const fs = require('@socketsupply/io/node/fs')
const writeFile = util.promisify(fs.writeFile)
const readFile = util.promisify(fs.readFile)
```