### PR TITLE
assert that the addr {address, port} object is the second arg

### DIFF
--- a/test/src/dgram.js
+++ b/test/src/dgram.js
@@ -97,7 +97,11 @@ test('udp bind, send, remoteAddress', async t => {
   const client = dgram.createSocket('udp4')
 
   const msg = new Promise((resolve, reject) => {
-    server.on('message', resolve)
+    server.on('message', (data, addr) => {
+      t.equal('number', typeof addr.port, 'port is a number')
+      t.equal(addr.address, '127.0.0.1')
+      resolve(data)
+    })
     server.on('error', reject)
   })
 


### PR DESCRIPTION
adds a test. I thought this might have been the issue @heapwolf was having, didn't see this case tested, so I added it. it passed for me, so this isn't it, but we should still have it as a test.